### PR TITLE
Correctly export module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 */.DS_Store
 node_modules
 *.log
-
+*.swp

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require('./lib/Logger');
+module.exports = require('./lib/Logger');

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -5,10 +5,7 @@ var config = {
     colorize: true,
     json: false,
     slient: false,
-    level: 'debug',
-    timestamp: function () {
-        return new Date().toUTCString();
-    }
+    level: 'debug'
 };
 
 // initialize
@@ -35,8 +32,6 @@ module.exports = {
 };
 
 function init() {
-    console.log(config.timestamp() + ' :: logger init() called. Updating Logger config...');
-
     // remove old transport defintion
     Logger.remove(Logger.transports.Console);
 

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -5,7 +5,6 @@ var config = {
     colorize: true,
     json: false,
     slient: false,
-    handleExceptions: true,
     level: 'debug',
     timestamp: function () {
         return new Date().toUTCString();
@@ -26,11 +25,17 @@ module.exports = {
     },
     get: function (key, val) {
         return config[key];
+    },
+    logToFile: function(file){
+      Logger.add(Logger.transports.File, {
+        filename: file,
+        json: false
+      });
     }
 };
 
 function init() {
-    console.log(config.timestamp + ' :: myLogger init() called. Updating Logger config...');
+    console.log(config.timestamp() + ' :: logger init() called. Updating Logger config...');
 
     // remove old transport defintion
     Logger.remove(Logger.transports.Console);

--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.10.0",
-    "grunt-shell": "~0.6.1",
-    "grunt-newer": "~0.5.4",
     "grunt-lintspaces": "^0.5.1",
+    "grunt-newer": "~0.5.4",
+    "grunt-shell": "~0.6.1",
     "jshint-stylish": "^0.4.0",
     "load-grunt-tasks": "~0.2.0",
-    "time-grunt": "~0.2.1",
-    "mocha": "^1.21.4"
+    "mocha": "^1.21.4",
+    "shelljs": "^0.3.0",
+    "time-grunt": "~0.2.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,7 @@
+var assert = require("assert");
+var fs = require("fs");
+require("shelljs/global");
+
 describe('myLogger module', function () {
 
     var Logger = require('../index'),
@@ -8,7 +12,7 @@ describe('myLogger module', function () {
         if (Logger) {
             done();
         } else {
-            return done('Failed to instantciate Logger');
+            return done('Failed to instantiate Logger');
         }
     });
 
@@ -17,7 +21,7 @@ describe('myLogger module', function () {
         if (myLogger) {
             done();
         } else {
-            return done('Failed to instantciate myLogger');
+            return done('Failed to instantiate myLogger');
         }
     });
 
@@ -32,7 +36,7 @@ describe('myLogger module', function () {
 
             done();
         } else {
-            return done('Failed to instantciate myLogger');
+            return done('Failed to instantiate myLogger');
         }
     });
 
@@ -43,7 +47,7 @@ describe('myLogger module', function () {
                 done();
             }
         } else {
-            return done('Failed to instantciate myLogger');
+            return done('Failed to instantiate myLogger');
         }
     });
 
@@ -54,7 +58,7 @@ describe('myLogger module', function () {
                 done();
             }
         } else {
-            return done('Failed to instantciate myLogger');
+            return done('Failed to instantiate myLogger');
         }
     });
 
@@ -65,7 +69,7 @@ describe('myLogger module', function () {
                 done();
             }
         } else {
-            return done('Failed to instantciate myLogger');
+            return done('Failed to instantiate myLogger');
         }
     });
 
@@ -76,7 +80,33 @@ describe('myLogger module', function () {
                 done();
             }
         } else {
-            return done('Failed to instantciate myLogger');
+            return done('Failed to instantiate myLogger');
         }
     });
+
+    it('should have logToFile available', function (done) {
+      assert(Logger["logToFile"]);
+      done();
+    });
+
+    it('should log to file if specified', function (done) {
+      var testFile = __dirname+"/test.tmp.log";
+      Logger.logToFile(testFile);
+      myLogger("info", "hello world", function(err){
+        assert(fs.existsSync(testFile));
+
+        var grepCommand = 'grep -q "hello world" ' + testFile;
+        exec(grepCommand, function(code){
+          assert(code === 0);
+
+          fs.unlink(testFile, function(err){
+            if(err){ assert(false); }
+            assert(fs.existsSync(testFile) === false);
+            done();
+          })
+
+        });
+      });
+    });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 describe('myLogger module', function () {
 
-    var Logger = require('./../lib/Logger'),
+    var Logger = require('../index'),
         myLogger = Logger.getLogger();
 
     // we use child process to excute parser via CLI


### PR DESCRIPTION
Hi there. The module is not being exported, resulting in an empty object being returned from `require("stdout-logger")` rather than the lib. See demonstrable test with fix.
